### PR TITLE
Update runtime to 50

### DIFF
--- a/io.github.tobagin.digger.yml
+++ b/io.github.tobagin.digger.yml
@@ -1,6 +1,6 @@
 app-id: io.github.tobagin.digger
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 command: digger-vala
 finish-args:
@@ -13,28 +13,10 @@ finish-args:
 cleanup:
   - /include
   - /lib/pkgconfig
-  - /man
-  - /share/doc
-  - /share/gtk-doc
-  - /share/man
-  - /share/pkgconfig
-  - /share/vala
   - '*.la'
   - '*.a'
 
 modules:
-  - name: libgee
-    buildsystem: autotools
-    config-opts:
-      - --disable-introspection
-      - --enable-vapi
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libgee/0.20/libgee-0.20.8.tar.xz
-        sha256: 189815ac143d89867193b0c52b7dc31f3aa108a15f04d6b5dca2b6adfad0b0ee
-        x-checker-data:
-          type: gnome
-          name: libgee
 
   # libuv dependency for BIND
   - name: libuv


### PR DESCRIPTION
- Update the runtime version to 50
- Use libgee module from the runtime
- Drop ineffective cleanup commands